### PR TITLE
Add payment-related entities with CLI CRUD

### DIFF
--- a/doc-embarque/backend/CMakeLists.txt
+++ b/doc-embarque/backend/CMakeLists.txt
@@ -31,6 +31,22 @@ add_executable(doc_embarque
         src/use_cases/read_contact.c
         src/use_cases/update_contact.c
         src/use_cases/delete_contact.c
+        src/use_cases/create_payment.c
+        src/use_cases/read_payment.c
+        src/use_cases/update_payment.c
+        src/use_cases/delete_payment.c
+        src/use_cases/create_installment.c
+        src/use_cases/read_installment.c
+        src/use_cases/update_installment.c
+        src/use_cases/delete_installment.c
+        src/use_cases/create_boarding.c
+        src/use_cases/read_boarding.c
+        src/use_cases/update_boarding.c
+        src/use_cases/delete_boarding.c
+        src/use_cases/create_travel_insurance.c
+        src/use_cases/read_travel_insurance.c
+        src/use_cases/update_travel_insurance.c
+        src/use_cases/delete_travel_insurance.c
 )
 
 set_target_properties(doc_embarque PROPERTIES

--- a/doc-embarque/backend/include/models/boarding.h
+++ b/doc-embarque/backend/include/models/boarding.h
@@ -1,0 +1,11 @@
+#ifndef BOARDING_H
+#define BOARDING_H
+
+typedef struct {
+    int id;
+    int student_id;
+    char date[20];
+    int boarded;
+} Boarding;
+
+#endif

--- a/doc-embarque/backend/include/models/installment.h
+++ b/doc-embarque/backend/include/models/installment.h
@@ -1,0 +1,12 @@
+#ifndef INSTALLMENT_H
+#define INSTALLMENT_H
+
+typedef struct {
+    int id;
+    int payment_id;
+    double amount;
+    char due_date[20];
+    int paid;
+} Installment;
+
+#endif

--- a/doc-embarque/backend/include/models/payment.h
+++ b/doc-embarque/backend/include/models/payment.h
@@ -1,0 +1,11 @@
+#ifndef PAYMENT_H
+#define PAYMENT_H
+
+typedef struct {
+    int id;
+    int student_id;
+    double amount;
+    char method[50];
+} Payment;
+
+#endif

--- a/doc-embarque/backend/include/models/travel_insurance.h
+++ b/doc-embarque/backend/include/models/travel_insurance.h
@@ -1,0 +1,11 @@
+#ifndef TRAVEL_INSURANCE_H
+#define TRAVEL_INSURANCE_H
+
+typedef struct {
+    int id;
+    int student_id;
+    char policy_number[50];
+    char provider[50];
+} TravelInsurance;
+
+#endif

--- a/doc-embarque/backend/include/use_cases/create_boarding.h
+++ b/doc-embarque/backend/include/use_cases/create_boarding.h
@@ -1,0 +1,12 @@
+#ifndef CREATE_BOARDING_H
+#define CREATE_BOARDING_H
+
+#include "../models/boarding.h"
+
+Boarding create_boarding(Boarding b);
+Boarding create_boarding_cli();
+int get_next_boarding_id();
+Boarding save_boarding(Boarding b);
+int verify_student_board(int id);
+
+#endif

--- a/doc-embarque/backend/include/use_cases/create_installment.h
+++ b/doc-embarque/backend/include/use_cases/create_installment.h
@@ -1,0 +1,12 @@
+#ifndef CREATE_INSTALLMENT_H
+#define CREATE_INSTALLMENT_H
+
+#include "../models/installment.h"
+
+Installment create_installment(Installment i);
+Installment create_installment_cli();
+int get_next_installment_id();
+Installment save_installment(Installment i);
+int verify_payment_installment(int id);
+
+#endif

--- a/doc-embarque/backend/include/use_cases/create_payment.h
+++ b/doc-embarque/backend/include/use_cases/create_payment.h
@@ -1,0 +1,12 @@
+#ifndef CREATE_PAYMENT_H
+#define CREATE_PAYMENT_H
+
+#include "../models/payment.h"
+
+Payment create_payment(Payment payment);
+Payment create_payment_cli();
+int get_next_payment_id();
+Payment save_payment(Payment p);
+int verify_student_payment(int id);
+
+#endif

--- a/doc-embarque/backend/include/use_cases/create_travel_insurance.h
+++ b/doc-embarque/backend/include/use_cases/create_travel_insurance.h
@@ -1,0 +1,12 @@
+#ifndef CREATE_TRAVEL_INSURANCE_H
+#define CREATE_TRAVEL_INSURANCE_H
+
+#include "../models/travel_insurance.h"
+
+TravelInsurance create_travel_insurance(TravelInsurance t);
+TravelInsurance create_travel_insurance_cli();
+int get_next_travel_insurance_id();
+TravelInsurance save_travel_insurance(TravelInsurance t);
+int verify_student_insurance(int id);
+
+#endif

--- a/doc-embarque/backend/include/use_cases/delete_boarding.h
+++ b/doc-embarque/backend/include/use_cases/delete_boarding.h
@@ -1,0 +1,6 @@
+#ifndef DELETE_BOARDING_H
+#define DELETE_BOARDING_H
+
+int delete_boarding(int id);
+
+#endif

--- a/doc-embarque/backend/include/use_cases/delete_installment.h
+++ b/doc-embarque/backend/include/use_cases/delete_installment.h
@@ -1,0 +1,6 @@
+#ifndef DELETE_INSTALLMENT_H
+#define DELETE_INSTALLMENT_H
+
+int delete_installment(int id);
+
+#endif

--- a/doc-embarque/backend/include/use_cases/delete_payment.h
+++ b/doc-embarque/backend/include/use_cases/delete_payment.h
@@ -1,0 +1,6 @@
+#ifndef DELETE_PAYMENT_H
+#define DELETE_PAYMENT_H
+
+int delete_payment(int id);
+
+#endif

--- a/doc-embarque/backend/include/use_cases/delete_travel_insurance.h
+++ b/doc-embarque/backend/include/use_cases/delete_travel_insurance.h
@@ -1,0 +1,6 @@
+#ifndef DELETE_TRAVEL_INSURANCE_H
+#define DELETE_TRAVEL_INSURANCE_H
+
+int delete_travel_insurance(int id);
+
+#endif

--- a/doc-embarque/backend/include/use_cases/read_boarding.h
+++ b/doc-embarque/backend/include/use_cases/read_boarding.h
@@ -1,0 +1,8 @@
+#ifndef READ_BOARDING_H
+#define READ_BOARDING_H
+
+#include "../models/boarding.h"
+
+void read_boardings();
+
+#endif

--- a/doc-embarque/backend/include/use_cases/read_installment.h
+++ b/doc-embarque/backend/include/use_cases/read_installment.h
@@ -1,0 +1,8 @@
+#ifndef READ_INSTALLMENT_H
+#define READ_INSTALLMENT_H
+
+#include "../models/installment.h"
+
+void read_installments();
+
+#endif

--- a/doc-embarque/backend/include/use_cases/read_payment.h
+++ b/doc-embarque/backend/include/use_cases/read_payment.h
@@ -1,0 +1,8 @@
+#ifndef READ_PAYMENT_H
+#define READ_PAYMENT_H
+
+#include "../models/payment.h"
+
+void read_payments();
+
+#endif

--- a/doc-embarque/backend/include/use_cases/read_travel_insurance.h
+++ b/doc-embarque/backend/include/use_cases/read_travel_insurance.h
@@ -1,0 +1,8 @@
+#ifndef READ_TRAVEL_INSURANCE_H
+#define READ_TRAVEL_INSURANCE_H
+
+#include "../models/travel_insurance.h"
+
+void read_travel_insurances();
+
+#endif

--- a/doc-embarque/backend/include/use_cases/update_boarding.h
+++ b/doc-embarque/backend/include/use_cases/update_boarding.h
@@ -1,0 +1,8 @@
+#ifndef UPDATE_BOARDING_H
+#define UPDATE_BOARDING_H
+
+#include "../models/boarding.h"
+
+int update_boarding(Boarding b);
+
+#endif

--- a/doc-embarque/backend/include/use_cases/update_installment.h
+++ b/doc-embarque/backend/include/use_cases/update_installment.h
@@ -1,0 +1,8 @@
+#ifndef UPDATE_INSTALLMENT_H
+#define UPDATE_INSTALLMENT_H
+
+#include "../models/installment.h"
+
+int update_installment(Installment i);
+
+#endif

--- a/doc-embarque/backend/include/use_cases/update_payment.h
+++ b/doc-embarque/backend/include/use_cases/update_payment.h
@@ -1,0 +1,8 @@
+#ifndef UPDATE_PAYMENT_H
+#define UPDATE_PAYMENT_H
+
+#include "../models/payment.h"
+
+int update_payment(Payment updated);
+
+#endif

--- a/doc-embarque/backend/include/use_cases/update_travel_insurance.h
+++ b/doc-embarque/backend/include/use_cases/update_travel_insurance.h
@@ -1,0 +1,8 @@
+#ifndef UPDATE_TRAVEL_INSURANCE_H
+#define UPDATE_TRAVEL_INSURANCE_H
+
+#include "../models/travel_insurance.h"
+
+int update_travel_insurance(TravelInsurance t);
+
+#endif

--- a/doc-embarque/backend/main.c
+++ b/doc-embarque/backend/main.c
@@ -7,6 +7,10 @@
 #include "include/models/class.h"
 #include "include/models/student.h"
 #include "include/models/contact.h"
+#include "include/models/payment.h"
+#include "include/models/installment.h"
+#include "include/models/boarding.h"
+#include "include/models/travel_insurance.h"
 
 #include "include/use_cases/create_user.h"
 #include "include/use_cases/login.h"
@@ -28,6 +32,22 @@
 #include "include/use_cases/read_contact.h"
 #include "include/use_cases/update_contact.h"
 #include "include/use_cases/delete_contact.h"
+#include "include/use_cases/create_payment.h"
+#include "include/use_cases/read_payment.h"
+#include "include/use_cases/update_payment.h"
+#include "include/use_cases/delete_payment.h"
+#include "include/use_cases/create_installment.h"
+#include "include/use_cases/read_installment.h"
+#include "include/use_cases/update_installment.h"
+#include "include/use_cases/delete_installment.h"
+#include "include/use_cases/create_boarding.h"
+#include "include/use_cases/read_boarding.h"
+#include "include/use_cases/update_boarding.h"
+#include "include/use_cases/delete_boarding.h"
+#include "include/use_cases/create_travel_insurance.h"
+#include "include/use_cases/read_travel_insurance.h"
+#include "include/use_cases/update_travel_insurance.h"
+#include "include/use_cases/delete_travel_insurance.h"
 
 static void print_menu() {
     printf("\n== DocEmbarque Teste ==\n");
@@ -51,6 +71,22 @@ static void print_menu() {
     printf("18 - Listar contatos\n");
     printf("19 - Atualizar contato\n");
     printf("20 - Remover contato\n");
+    printf("21 - Criar pagamento\n");
+    printf("22 - Listar pagamentos\n");
+    printf("23 - Atualizar pagamento\n");
+    printf("24 - Remover pagamento\n");
+    printf("25 - Criar parcela\n");
+    printf("26 - Listar parcelas\n");
+    printf("27 - Atualizar parcela\n");
+    printf("28 - Remover parcela\n");
+    printf("29 - Registrar embarque\n");
+    printf("30 - Listar embarques\n");
+    printf("31 - Atualizar embarque\n");
+    printf("32 - Remover embarque\n");
+    printf("33 - Criar seguro viagem\n");
+    printf("34 - Listar seguros\n");
+    printf("35 - Atualizar seguro\n");
+    printf("36 - Remover seguro\n");
     printf("0 - Sair\n> ");
 }
 
@@ -246,6 +282,171 @@ int main() {
                     printf("Contato removido.\n");
                 else
                     printf("Contato não encontrado.\n");
+                break;
+            }
+            case 21: {
+                Payment p = create_payment_cli();
+                if (p.id != -1)
+                    printf("Pagamento registrado com ID %d.\n", p.id);
+                break;
+            }
+            case 22:
+                read_payments();
+                break;
+            case 23: {
+                Payment p;
+                char buffer[128];
+                printf("ID do pagamento: ");
+                fgets(buffer, sizeof(buffer), stdin);
+                p.id = atoi(buffer);
+                printf("ID do aluno (0 para manter): ");
+                fgets(buffer, sizeof(buffer), stdin);
+                p.student_id = atoi(buffer);
+                printf("Valor (0 para manter): ");
+                fgets(buffer, sizeof(buffer), stdin);
+                p.amount = atof(buffer);
+                printf("Metodo (deixe vazio para manter): ");
+                fgets(p.method, sizeof(p.method), stdin);
+                p.method[strcspn(p.method, "\n")] = '\0';
+                if (update_payment(p))
+                    printf("Pagamento atualizado.\n");
+                else
+                    printf("Pagamento não encontrado.\n");
+                break;
+            }
+            case 24: {
+                char buf[32];
+                printf("ID do pagamento a remover: ");
+                fgets(buf, sizeof(buf), stdin);
+                if (delete_payment(atoi(buf)))
+                    printf("Pagamento removido.\n");
+                else
+                    printf("Pagamento não encontrado.\n");
+                break;
+            }
+            case 25: {
+                Installment i = create_installment_cli();
+                if (i.id != -1)
+                    printf("Parcela criada com ID %d.\n", i.id);
+                break;
+            }
+            case 26:
+                read_installments();
+                break;
+            case 27: {
+                Installment i;
+                char buffer[128];
+                printf("ID da parcela: ");
+                fgets(buffer, sizeof(buffer), stdin);
+                i.id = atoi(buffer);
+                printf("ID do pagamento (0 para manter): ");
+                fgets(buffer, sizeof(buffer), stdin);
+                i.payment_id = atoi(buffer);
+                printf("Valor (0 para manter): ");
+                fgets(buffer, sizeof(buffer), stdin);
+                i.amount = atof(buffer);
+                printf("Vencimento (deixe vazio para manter): ");
+                fgets(i.due_date, sizeof(i.due_date), stdin);
+                i.due_date[strcspn(i.due_date, "\n")] = '\0';
+                printf("Pago (0/1 ou -1 para manter): ");
+                fgets(buffer, sizeof(buffer), stdin);
+                i.paid = atoi(buffer);
+                if (i.paid != 0 && i.paid != 1) i.paid = -1;
+                if (update_installment(i))
+                    printf("Parcela atualizada.\n");
+                else
+                    printf("Parcela não encontrada.\n");
+                break;
+            }
+            case 28: {
+                char buf[32];
+                printf("ID da parcela a remover: ");
+                fgets(buf, sizeof(buf), stdin);
+                if (delete_installment(atoi(buf)))
+                    printf("Parcela removida.\n");
+                else
+                    printf("Parcela não encontrada.\n");
+                break;
+            }
+            case 29: {
+                Boarding b = create_boarding_cli();
+                if (b.id != -1)
+                    printf("Embarque registrado com ID %d.\n", b.id);
+                break;
+            }
+            case 30:
+                read_boardings();
+                break;
+            case 31: {
+                Boarding b;
+                char buffer[128];
+                printf("ID do embarque: ");
+                fgets(buffer, sizeof(buffer), stdin);
+                b.id = atoi(buffer);
+                printf("ID do aluno (0 para manter): ");
+                fgets(buffer, sizeof(buffer), stdin);
+                b.student_id = atoi(buffer);
+                printf("Data (deixe vazio para manter): ");
+                fgets(b.date, sizeof(b.date), stdin);
+                b.date[strcspn(b.date, "\n")] = '\0';
+                printf("Embarcou (0/1 ou -1 para manter): ");
+                fgets(buffer, sizeof(buffer), stdin);
+                b.boarded = atoi(buffer);
+                if (b.boarded != 0 && b.boarded != 1) b.boarded = -1;
+                if (update_boarding(b))
+                    printf("Embarque atualizado.\n");
+                else
+                    printf("Embarque não encontrado.\n");
+                break;
+            }
+            case 32: {
+                char buf[32];
+                printf("ID do embarque a remover: ");
+                fgets(buf, sizeof(buf), stdin);
+                if (delete_boarding(atoi(buf)))
+                    printf("Embarque removido.\n");
+                else
+                    printf("Embarque não encontrado.\n");
+                break;
+            }
+            case 33: {
+                TravelInsurance t = create_travel_insurance_cli();
+                if (t.id != -1)
+                    printf("Seguro criado com ID %d.\n", t.id);
+                break;
+            }
+            case 34:
+                read_travel_insurances();
+                break;
+            case 35: {
+                TravelInsurance t;
+                char buffer[128];
+                printf("ID do seguro: ");
+                fgets(buffer, sizeof(buffer), stdin);
+                t.id = atoi(buffer);
+                printf("ID do aluno (0 para manter): ");
+                fgets(buffer, sizeof(buffer), stdin);
+                t.student_id = atoi(buffer);
+                printf("Numero da apolice (deixe vazio para manter): ");
+                fgets(t.policy_number, sizeof(t.policy_number), stdin);
+                t.policy_number[strcspn(t.policy_number, "\n")] = '\0';
+                printf("Seguradora (deixe vazio para manter): ");
+                fgets(t.provider, sizeof(t.provider), stdin);
+                t.provider[strcspn(t.provider, "\n")] = '\0';
+                if (update_travel_insurance(t))
+                    printf("Seguro atualizado.\n");
+                else
+                    printf("Seguro não encontrado.\n");
+                break;
+            }
+            case 36: {
+                char buf[32];
+                printf("ID do seguro a remover: ");
+                fgets(buf, sizeof(buf), stdin);
+                if (delete_travel_insurance(atoi(buf)))
+                    printf("Seguro removido.\n");
+                else
+                    printf("Seguro não encontrado.\n");
                 break;
             }
             case 0:

--- a/doc-embarque/backend/src/use_cases/create_boarding.c
+++ b/doc-embarque/backend/src/use_cases/create_boarding.c
@@ -1,0 +1,71 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "../../include/models/boarding.h"
+#include "../../include/models/student.h"
+#include "../../include/use_cases/create_boarding.h"
+#include "../../include/utils.h"
+
+#define FILE_PATH "../../data/boarding.txt"
+#define STUDENT_FILE "../../data/students.txt"
+
+int get_next_boarding_id() {
+    FILE *file = fopen(FILE_PATH, "r");
+    int id = 0, temp;
+    Boarding b;
+    if (file != NULL) {
+        while (fscanf(file, "%d;%d;%[^;];%d\n", &temp, &b.student_id, b.date, &b.boarded) == 4) {
+            if (temp > id) id = temp;
+        }
+        fclose(file);
+    }
+    return id + 1;
+}
+
+int verify_student_board(int id) {
+    FILE *file = fopen(STUDENT_FILE, "r");
+    Student s; int temp; int found = 0;
+    if (file != NULL) {
+        while (fscanf(file, "%d;%d;%[^;];%[^;];%[^;];%[^\n]\n", &temp, &s.classroom_id, s.name, s.rg, s.cpf, s.birth_date) == 6) {
+            if (temp == id) { found = 1; break; }
+        }
+        fclose(file);
+    }
+    return found;
+}
+
+Boarding save_boarding(Boarding b) {
+    ensure_data_directory();
+    FILE *file = fopen(FILE_PATH, "a");
+    if (!file) {
+        perror("Erro ao abrir o arquivo");
+        return b;
+    }
+    fprintf(file, "%d;%d;%s;%d\n", b.id, b.student_id, b.date, b.boarded);
+    fclose(file);
+    return b;
+}
+
+Boarding create_boarding(Boarding b) {
+    b.id = get_next_boarding_id();
+    return save_boarding(b);
+}
+
+Boarding create_boarding_cli() {
+    Boarding b;
+    printf("ID do aluno: ");
+    scanf("%d", &b.student_id);
+    getchar();
+    if (!verify_student_board(b.student_id)) {
+        printf("Aluno com ID %d não encontrado.\n", b.student_id);
+        b.id = -1;
+        return b;
+    }
+    printf("Data do embarque: ");
+    fgets(b.date, sizeof(b.date), stdin);
+    strtok(b.date, "\n");
+    b.boarded = 1;
+    b = create_boarding(b);
+    if (b.id != -1) printf("Embarque salvo com sucesso.\n");
+    return b;
+}

--- a/doc-embarque/backend/src/use_cases/create_installment.c
+++ b/doc-embarque/backend/src/use_cases/create_installment.c
@@ -1,0 +1,74 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "../../include/models/installment.h"
+#include "../../include/models/payment.h"
+#include "../../include/use_cases/create_installment.h"
+#include "../../include/utils.h"
+
+#define FILE_PATH "../../data/installments.txt"
+#define PAYMENT_FILE "../../data/payments.txt"
+
+int get_next_installment_id() {
+    FILE *file = fopen(FILE_PATH, "r");
+    int id = 0, temp;
+    Installment i;
+    if (file != NULL) {
+        while (fscanf(file, "%d;%d;%lf;%[^;];%d\n", &temp, &i.payment_id, &i.amount, i.due_date, &i.paid) == 5) {
+            if (temp > id) id = temp;
+        }
+        fclose(file);
+    }
+    return id + 1;
+}
+
+int verify_payment_installment(int id) {
+    FILE *file = fopen(PAYMENT_FILE, "r");
+    Payment p; int temp; int found = 0;
+    if (file != NULL) {
+        while (fscanf(file, "%d;%d;%lf;%[^\n]\n", &temp, &p.student_id, &p.amount, p.method) == 4) {
+            if (temp == id) { found = 1; break; }
+        }
+        fclose(file);
+    }
+    return found;
+}
+
+Installment save_installment(Installment i) {
+    ensure_data_directory();
+    FILE *file = fopen(FILE_PATH, "a");
+    if (!file) {
+        perror("Erro ao abrir o arquivo");
+        return i;
+    }
+    fprintf(file, "%d;%d;%.2lf;%s;%d\n", i.id, i.payment_id, i.amount, i.due_date, i.paid);
+    fclose(file);
+    return i;
+}
+
+Installment create_installment(Installment i) {
+    i.id = get_next_installment_id();
+    return save_installment(i);
+}
+
+Installment create_installment_cli() {
+    Installment i;
+    printf("ID do pagamento: ");
+    scanf("%d", &i.payment_id);
+    getchar();
+    if (!verify_payment_installment(i.payment_id)) {
+        printf("Pagamento com ID %d não encontrado.\n", i.payment_id);
+        i.id = -1;
+        return i;
+    }
+    printf("Valor da parcela: ");
+    scanf("%lf", &i.amount);
+    getchar();
+    printf("Vencimento: ");
+    fgets(i.due_date, sizeof(i.due_date), stdin);
+    strtok(i.due_date, "\n");
+    i.paid = 0;
+    i = create_installment(i);
+    if (i.id != -1) printf("Parcela salva com sucesso.\n");
+    return i;
+}

--- a/doc-embarque/backend/src/use_cases/create_payment.c
+++ b/doc-embarque/backend/src/use_cases/create_payment.c
@@ -1,0 +1,74 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "../../include/models/payment.h"
+#include "../../include/models/student.h"
+#include "../../include/use_cases/create_payment.h"
+#include "../../include/utils.h"
+
+#define FILE_PATH "../../data/payments.txt"
+#define STUDENT_FILE "../../data/students.txt"
+
+int get_next_payment_id() {
+    FILE *file = fopen(FILE_PATH, "r");
+    int id = 0, temp;
+    Payment p;
+
+    if (file != NULL) {
+        while (fscanf(file, "%d;%d;%lf;%[^\n]\n", &temp, &p.student_id, &p.amount, p.method) == 4) {
+            if (temp > id) id = temp;
+        }
+        fclose(file);
+    }
+    return id + 1;
+}
+
+int verify_student_payment(int id) {
+    FILE *file = fopen(STUDENT_FILE, "r");
+    Student s; int temp; int found = 0;
+    if (file != NULL) {
+        while (fscanf(file, "%d;%d;%[^;];%[^;];%[^;];%[^\n]\n", &temp, &s.classroom_id, s.name, s.rg, s.cpf, s.birth_date) == 6) {
+            if (temp == id) { found = 1; break; }
+        }
+        fclose(file);
+    }
+    return found;
+}
+
+Payment save_payment(Payment p) {
+    ensure_data_directory();
+    FILE *file = fopen(FILE_PATH, "a");
+    if (!file) {
+        perror("Erro ao abrir o arquivo");
+        return p;
+    }
+    fprintf(file, "%d;%d;%.2lf;%s\n", p.id, p.student_id, p.amount, p.method);
+    fclose(file);
+    return p;
+}
+
+Payment create_payment(Payment p) {
+    p.id = get_next_payment_id();
+    return save_payment(p);
+}
+
+Payment create_payment_cli() {
+    Payment p;
+    printf("ID do aluno: ");
+    scanf("%d", &p.student_id);
+    getchar();
+    if (!verify_student_payment(p.student_id)) {
+        printf("Aluno com ID %d não encontrado.\n", p.student_id);
+        p.id = -1;
+        return p;
+    }
+    printf("Valor: ");
+    scanf("%lf", &p.amount);
+    getchar();
+    printf("Metodo de pagamento: ");
+    fgets(p.method, sizeof(p.method), stdin);
+    strtok(p.method, "\n");
+    p = create_payment(p);
+    if (p.id != -1) printf("Pagamento salvo com sucesso.\n");
+    return p;
+}

--- a/doc-embarque/backend/src/use_cases/create_travel_insurance.c
+++ b/doc-embarque/backend/src/use_cases/create_travel_insurance.c
@@ -1,0 +1,73 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "../../include/models/travel_insurance.h"
+#include "../../include/models/student.h"
+#include "../../include/use_cases/create_travel_insurance.h"
+#include "../../include/utils.h"
+
+#define FILE_PATH "../../data/travel_insurance.txt"
+#define STUDENT_FILE "../../data/students.txt"
+
+int get_next_travel_insurance_id() {
+    FILE *file = fopen(FILE_PATH, "r");
+    int id = 0, temp;
+    TravelInsurance t;
+    if (file != NULL) {
+        while (fscanf(file, "%d;%d;%[^;];%[^\n]\n", &temp, &t.student_id, t.policy_number, t.provider) == 4) {
+            if (temp > id) id = temp;
+        }
+        fclose(file);
+    }
+    return id + 1;
+}
+
+int verify_student_insurance(int id) {
+    FILE *file = fopen(STUDENT_FILE, "r");
+    Student s; int temp; int found = 0;
+    if (file != NULL) {
+        while (fscanf(file, "%d;%d;%[^;];%[^;];%[^;];%[^\n]\n", &temp, &s.classroom_id, s.name, s.rg, s.cpf, s.birth_date) == 6) {
+            if (temp == id) { found = 1; break; }
+        }
+        fclose(file);
+    }
+    return found;
+}
+
+TravelInsurance save_travel_insurance(TravelInsurance t) {
+    ensure_data_directory();
+    FILE *file = fopen(FILE_PATH, "a");
+    if (!file) {
+        perror("Erro ao abrir o arquivo");
+        return t;
+    }
+    fprintf(file, "%d;%d;%s;%s\n", t.id, t.student_id, t.policy_number, t.provider);
+    fclose(file);
+    return t;
+}
+
+TravelInsurance create_travel_insurance(TravelInsurance t) {
+    t.id = get_next_travel_insurance_id();
+    return save_travel_insurance(t);
+}
+
+TravelInsurance create_travel_insurance_cli() {
+    TravelInsurance t;
+    printf("ID do aluno: ");
+    scanf("%d", &t.student_id);
+    getchar();
+    if (!verify_student_insurance(t.student_id)) {
+        printf("Aluno com ID %d não encontrado.\n", t.student_id);
+        t.id = -1;
+        return t;
+    }
+    printf("Numero da apolice: ");
+    fgets(t.policy_number, sizeof(t.policy_number), stdin);
+    strtok(t.policy_number, "\n");
+    printf("Seguradora: ");
+    fgets(t.provider, sizeof(t.provider), stdin);
+    strtok(t.provider, "\n");
+    t = create_travel_insurance(t);
+    if (t.id != -1) printf("Seguro salvo com sucesso.\n");
+    return t;
+}

--- a/doc-embarque/backend/src/use_cases/delete_boarding.c
+++ b/doc-embarque/backend/src/use_cases/delete_boarding.c
@@ -1,0 +1,48 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../include/models/boarding.h"
+#include "../../include/use_cases/delete_boarding.h"
+
+#define FILE_PATH "../../data/boarding.txt"
+#define TEMP_PATH "../../data/boarding.tmp"
+
+int delete_boarding(int id) {
+    FILE *file = fopen(FILE_PATH, "r");
+    if (!file) {
+        perror("Erro ao abrir o arquivo");
+        return 0;
+    }
+
+    FILE *temp = fopen(TEMP_PATH, "w");
+    if (!temp) {
+        perror("Erro ao criar arquivo temporario");
+        fclose(file);
+        return 0;
+    }
+
+    Boarding b;
+    int curr_id;
+    int found = 0;
+
+    while (fscanf(file, "%d;%d;%[^;];%d\n", &curr_id, &b.student_id, b.date, &b.boarded) == 4) {
+        if (curr_id == id) {
+            found = 1;
+            continue;
+        }
+        fprintf(temp, "%d;%d;%s;%d\n", curr_id, b.student_id, b.date, b.boarded);
+    }
+
+    fclose(file);
+    fclose(temp);
+
+    if (!found) {
+        remove(TEMP_PATH);
+        return 0;
+    }
+
+    remove(FILE_PATH);
+    rename(TEMP_PATH, FILE_PATH);
+    return 1;
+}

--- a/doc-embarque/backend/src/use_cases/delete_installment.c
+++ b/doc-embarque/backend/src/use_cases/delete_installment.c
@@ -1,0 +1,48 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../include/models/installment.h"
+#include "../../include/use_cases/delete_installment.h"
+
+#define FILE_PATH "../../data/installments.txt"
+#define TEMP_PATH "../../data/installments.tmp"
+
+int delete_installment(int id) {
+    FILE *file = fopen(FILE_PATH, "r");
+    if (!file) {
+        perror("Erro ao abrir o arquivo");
+        return 0;
+    }
+
+    FILE *temp = fopen(TEMP_PATH, "w");
+    if (!temp) {
+        perror("Erro ao criar arquivo temporario");
+        fclose(file);
+        return 0;
+    }
+
+    Installment i;
+    int curr_id;
+    int found = 0;
+
+    while (fscanf(file, "%d;%d;%lf;%[^;];%d\n", &curr_id, &i.payment_id, &i.amount, i.due_date, &i.paid) == 5) {
+        if (curr_id == id) {
+            found = 1;
+            continue;
+        }
+        fprintf(temp, "%d;%d;%.2lf;%s;%d\n", curr_id, i.payment_id, i.amount, i.due_date, i.paid);
+    }
+
+    fclose(file);
+    fclose(temp);
+
+    if (!found) {
+        remove(TEMP_PATH);
+        return 0;
+    }
+
+    remove(FILE_PATH);
+    rename(TEMP_PATH, FILE_PATH);
+    return 1;
+}

--- a/doc-embarque/backend/src/use_cases/delete_payment.c
+++ b/doc-embarque/backend/src/use_cases/delete_payment.c
@@ -1,0 +1,48 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../include/models/payment.h"
+#include "../../include/use_cases/delete_payment.h"
+
+#define FILE_PATH "../../data/payments.txt"
+#define TEMP_PATH "../../data/payments.tmp"
+
+int delete_payment(int id) {
+    FILE *file = fopen(FILE_PATH, "r");
+    if (!file) {
+        perror("Erro ao abrir o arquivo");
+        return 0;
+    }
+
+    FILE *temp = fopen(TEMP_PATH, "w");
+    if (!temp) {
+        perror("Erro ao criar arquivo temporario");
+        fclose(file);
+        return 0;
+    }
+
+    Payment p;
+    int curr_id;
+    int found = 0;
+
+    while (fscanf(file, "%d;%d;%lf;%[^\n]\n", &curr_id, &p.student_id, &p.amount, p.method) == 4) {
+        if (curr_id == id) {
+            found = 1;
+            continue;
+        }
+        fprintf(temp, "%d;%d;%.2lf;%s\n", curr_id, p.student_id, p.amount, p.method);
+    }
+
+    fclose(file);
+    fclose(temp);
+
+    if (!found) {
+        remove(TEMP_PATH);
+        return 0;
+    }
+
+    remove(FILE_PATH);
+    rename(TEMP_PATH, FILE_PATH);
+    return 1;
+}

--- a/doc-embarque/backend/src/use_cases/delete_travel_insurance.c
+++ b/doc-embarque/backend/src/use_cases/delete_travel_insurance.c
@@ -1,0 +1,48 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../include/models/travel_insurance.h"
+#include "../../include/use_cases/delete_travel_insurance.h"
+
+#define FILE_PATH "../../data/travel_insurance.txt"
+#define TEMP_PATH "../../data/travel_insurance.tmp"
+
+int delete_travel_insurance(int id) {
+    FILE *file = fopen(FILE_PATH, "r");
+    if (!file) {
+        perror("Erro ao abrir o arquivo");
+        return 0;
+    }
+
+    FILE *temp = fopen(TEMP_PATH, "w");
+    if (!temp) {
+        perror("Erro ao criar arquivo temporario");
+        fclose(file);
+        return 0;
+    }
+
+    TravelInsurance t;
+    int curr_id;
+    int found = 0;
+
+    while (fscanf(file, "%d;%d;%[^;];%[^\n]\n", &curr_id, &t.student_id, t.policy_number, t.provider) == 4) {
+        if (curr_id == id) {
+            found = 1;
+            continue;
+        }
+        fprintf(temp, "%d;%d;%s;%s\n", curr_id, t.student_id, t.policy_number, t.provider);
+    }
+
+    fclose(file);
+    fclose(temp);
+
+    if (!found) {
+        remove(TEMP_PATH);
+        return 0;
+    }
+
+    remove(FILE_PATH);
+    rename(TEMP_PATH, FILE_PATH);
+    return 1;
+}

--- a/doc-embarque/backend/src/use_cases/read_boarding.c
+++ b/doc-embarque/backend/src/use_cases/read_boarding.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+
+#include "../../include/models/boarding.h"
+#include "../../include/use_cases/read_boarding.h"
+
+#define FILE_PATH "../../data/boarding.txt"
+
+void read_boardings() {
+    FILE *file = fopen(FILE_PATH, "r");
+    if (!file) {
+        printf("Erro ao abrir o arquivo.\n");
+        return;
+    }
+
+    Boarding b;
+    while (fscanf(file, "%d;%d;%[^;];%d\n", &b.id, &b.student_id, b.date, &b.boarded) == 4) {
+        printf("ID: %d | Aluno: %d | Data: %s | Embarcou: %d\n", b.id, b.student_id, b.date, b.boarded);
+    }
+
+    fclose(file);
+}

--- a/doc-embarque/backend/src/use_cases/read_installment.c
+++ b/doc-embarque/backend/src/use_cases/read_installment.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+
+#include "../../include/models/installment.h"
+#include "../../include/use_cases/read_installment.h"
+
+#define FILE_PATH "../../data/installments.txt"
+
+void read_installments() {
+    FILE *file = fopen(FILE_PATH, "r");
+    if (!file) {
+        printf("Erro ao abrir o arquivo.\n");
+        return;
+    }
+
+    Installment i;
+    while (fscanf(file, "%d;%d;%lf;%[^;];%d\n", &i.id, &i.payment_id, &i.amount, i.due_date, &i.paid) == 5) {
+        printf("ID: %d | Pagamento: %d | Valor: %.2lf | Vencimento: %s | Pago: %d\n", i.id, i.payment_id, i.amount, i.due_date, i.paid);
+    }
+
+    fclose(file);
+}

--- a/doc-embarque/backend/src/use_cases/read_payment.c
+++ b/doc-embarque/backend/src/use_cases/read_payment.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+
+#include "../../include/models/payment.h"
+#include "../../include/use_cases/read_payment.h"
+
+#define FILE_PATH "../../data/payments.txt"
+
+void read_payments() {
+    FILE *file = fopen(FILE_PATH, "r");
+    if (!file) {
+        printf("Erro ao abrir o arquivo.\n");
+        return;
+    }
+
+    Payment p;
+    while (fscanf(file, "%d;%d;%lf;%[^\n]\n", &p.id, &p.student_id, &p.amount, p.method) == 4) {
+        printf("ID: %d | Aluno: %d | Valor: %.2lf | Metodo: %s\n", p.id, p.student_id, p.amount, p.method);
+    }
+
+    fclose(file);
+}

--- a/doc-embarque/backend/src/use_cases/read_travel_insurance.c
+++ b/doc-embarque/backend/src/use_cases/read_travel_insurance.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+
+#include "../../include/models/travel_insurance.h"
+#include "../../include/use_cases/read_travel_insurance.h"
+
+#define FILE_PATH "../../data/travel_insurance.txt"
+
+void read_travel_insurances() {
+    FILE *file = fopen(FILE_PATH, "r");
+    if (!file) {
+        printf("Erro ao abrir o arquivo.\n");
+        return;
+    }
+
+    TravelInsurance t;
+    while (fscanf(file, "%d;%d;%[^;];%[^\n]\n", &t.id, &t.student_id, t.policy_number, t.provider) == 4) {
+        printf("ID: %d | Aluno: %d | Apolice: %s | Seguradora: %s\n", t.id, t.student_id, t.policy_number, t.provider);
+    }
+
+    fclose(file);
+}

--- a/doc-embarque/backend/src/use_cases/update_boarding.c
+++ b/doc-embarque/backend/src/use_cases/update_boarding.c
@@ -1,0 +1,50 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../include/models/boarding.h"
+#include "../../include/use_cases/update_boarding.h"
+
+#define FILE_PATH "../../data/boarding.txt"
+#define TEMP_PATH "../../data/boarding.tmp"
+
+int update_boarding(Boarding updated) {
+    FILE *file = fopen(FILE_PATH, "r");
+    if (!file) {
+        perror("Erro ao abrir o arquivo");
+        return 0;
+    }
+
+    FILE *temp = fopen(TEMP_PATH, "w");
+    if (!temp) {
+        perror("Erro ao criar arquivo temporario");
+        fclose(file);
+        return 0;
+    }
+
+    Boarding curr;
+    int id;
+    int found = 0;
+
+    while (fscanf(file, "%d;%d;%[^;];%d\n", &id, &curr.student_id, curr.date, &curr.boarded) == 4) {
+        if (id == updated.id) {
+            found = 1;
+            if (updated.student_id != 0) curr.student_id = updated.student_id;
+            if (strlen(updated.date) > 0) strcpy(curr.date, updated.date);
+            if (updated.boarded != -1) curr.boarded = updated.boarded;
+        }
+        fprintf(temp, "%d;%d;%s;%d\n", id, curr.student_id, curr.date, curr.boarded);
+    }
+
+    fclose(file);
+    fclose(temp);
+
+    if (!found) {
+        remove(TEMP_PATH);
+        return 0;
+    }
+
+    remove(FILE_PATH);
+    rename(TEMP_PATH, FILE_PATH);
+    return 1;
+}

--- a/doc-embarque/backend/src/use_cases/update_installment.c
+++ b/doc-embarque/backend/src/use_cases/update_installment.c
@@ -1,0 +1,51 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../include/models/installment.h"
+#include "../../include/use_cases/update_installment.h"
+
+#define FILE_PATH "../../data/installments.txt"
+#define TEMP_PATH "../../data/installments.tmp"
+
+int update_installment(Installment updated) {
+    FILE *file = fopen(FILE_PATH, "r");
+    if (!file) {
+        perror("Erro ao abrir o arquivo");
+        return 0;
+    }
+
+    FILE *temp = fopen(TEMP_PATH, "w");
+    if (!temp) {
+        perror("Erro ao criar arquivo temporario");
+        fclose(file);
+        return 0;
+    }
+
+    Installment curr;
+    int id;
+    int found = 0;
+
+    while (fscanf(file, "%d;%d;%lf;%[^;];%d\n", &id, &curr.payment_id, &curr.amount, curr.due_date, &curr.paid) == 5) {
+        if (id == updated.id) {
+            found = 1;
+            if (updated.payment_id != 0) curr.payment_id = updated.payment_id;
+            if (updated.amount != 0) curr.amount = updated.amount;
+            if (strlen(updated.due_date) > 0) strcpy(curr.due_date, updated.due_date);
+            if (updated.paid != -1) curr.paid = updated.paid;
+        }
+        fprintf(temp, "%d;%d;%.2lf;%s;%d\n", id, curr.payment_id, curr.amount, curr.due_date, curr.paid);
+    }
+
+    fclose(file);
+    fclose(temp);
+
+    if (!found) {
+        remove(TEMP_PATH);
+        return 0;
+    }
+
+    remove(FILE_PATH);
+    rename(TEMP_PATH, FILE_PATH);
+    return 1;
+}

--- a/doc-embarque/backend/src/use_cases/update_payment.c
+++ b/doc-embarque/backend/src/use_cases/update_payment.c
@@ -1,0 +1,50 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../include/models/payment.h"
+#include "../../include/use_cases/update_payment.h"
+
+#define FILE_PATH "../../data/payments.txt"
+#define TEMP_PATH "../../data/payments.tmp"
+
+int update_payment(Payment updated) {
+    FILE *file = fopen(FILE_PATH, "r");
+    if (!file) {
+        perror("Erro ao abrir o arquivo");
+        return 0;
+    }
+
+    FILE *temp = fopen(TEMP_PATH, "w");
+    if (!temp) {
+        perror("Erro ao criar arquivo temporario");
+        fclose(file);
+        return 0;
+    }
+
+    Payment curr;
+    int id;
+    int found = 0;
+
+    while (fscanf(file, "%d;%d;%lf;%[^\n]\n", &id, &curr.student_id, &curr.amount, curr.method) == 4) {
+        if (id == updated.id) {
+            found = 1;
+            if (updated.student_id != 0) curr.student_id = updated.student_id;
+            if (updated.amount != 0) curr.amount = updated.amount;
+            if (strlen(updated.method) > 0) strcpy(curr.method, updated.method);
+        }
+        fprintf(temp, "%d;%d;%.2lf;%s\n", id, curr.student_id, curr.amount, curr.method);
+    }
+
+    fclose(file);
+    fclose(temp);
+
+    if (!found) {
+        remove(TEMP_PATH);
+        return 0;
+    }
+
+    remove(FILE_PATH);
+    rename(TEMP_PATH, FILE_PATH);
+    return 1;
+}

--- a/doc-embarque/backend/src/use_cases/update_travel_insurance.c
+++ b/doc-embarque/backend/src/use_cases/update_travel_insurance.c
@@ -1,0 +1,50 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../include/models/travel_insurance.h"
+#include "../../include/use_cases/update_travel_insurance.h"
+
+#define FILE_PATH "../../data/travel_insurance.txt"
+#define TEMP_PATH "../../data/travel_insurance.tmp"
+
+int update_travel_insurance(TravelInsurance updated) {
+    FILE *file = fopen(FILE_PATH, "r");
+    if (!file) {
+        perror("Erro ao abrir o arquivo");
+        return 0;
+    }
+
+    FILE *temp = fopen(TEMP_PATH, "w");
+    if (!temp) {
+        perror("Erro ao criar arquivo temporario");
+        fclose(file);
+        return 0;
+    }
+
+    TravelInsurance curr;
+    int id;
+    int found = 0;
+
+    while (fscanf(file, "%d;%d;%[^;];%[^\n]\n", &id, &curr.student_id, curr.policy_number, curr.provider) == 4) {
+        if (id == updated.id) {
+            found = 1;
+            if (updated.student_id != 0) curr.student_id = updated.student_id;
+            if (strlen(updated.policy_number) > 0) strcpy(curr.policy_number, updated.policy_number);
+            if (strlen(updated.provider) > 0) strcpy(curr.provider, updated.provider);
+        }
+        fprintf(temp, "%d;%d;%s;%s\n", id, curr.student_id, curr.policy_number, curr.provider);
+    }
+
+    fclose(file);
+    fclose(temp);
+
+    if (!found) {
+        remove(TEMP_PATH);
+        return 0;
+    }
+
+    remove(FILE_PATH);
+    rename(TEMP_PATH, FILE_PATH);
+    return 1;
+}


### PR DESCRIPTION
## Summary
- define new data models for payments, installments, boarding and travel insurance
- add CRUD headers for those models
- implement file based persistence for the new entities
- extend the CLI to handle these new actions
- update build to compile new source files

## Testing
- `cmake ..`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_684b1c7bd54c832da4f105a23ab77e96